### PR TITLE
Filtering implemented

### DIFF
--- a/web/app/view/edit/Users.js
+++ b/web/app/view/edit/Users.js
@@ -122,7 +122,10 @@ Ext.define('Traccar.view.edit.Users', {
         }, {
             text: Strings.userEmail,
             dataIndex: 'email',
-            filter: 'string'
+            reference: 'userEmailColumn',
+            filter: {
+                type: 'string'
+            }
         }, {
             text: Strings.userAdmin,
             dataIndex: 'admin',


### PR DESCRIPTION
* Implemented custom filtering for Users view from UserController
* Redefined filter's setActive method for better UX
### Implemented custom filtering
Limited count of users is done from backend part in https://github.com/siilats/traccarbolt/pull/10, From frontend part I firing custom endpoint when email filter is triggered. I had trouble with `setActive()` method, when I override it, UX is gone(it wasn't bold when filter was activated etc). So I had to duplicate code from super class [Ext.grid.filters.filter.Base](https://docs.sencha.com/ext/6.2.0/classic/Ext.grid.filters.filter.Base.html#placeholder-setActive). I think this can be done more beautifully.