### PR TITLE
Renamed filtering param to email

### DIFF
--- a/web/app/view/edit/UsersController.js
+++ b/web/app/view/edit/UsersController.js
@@ -75,7 +75,7 @@ Ext.define('Traccar.view.edit.UsersController', {
             if (!value.lastValue) {
                 store.load();
             } else {
-                store.load({url: 'api/users/filter?phrase=' + encodeURIComponent(value.lastValue)});
+                store.load({url: 'api/users/filter?email=' + encodeURIComponent(value.lastValue)});
             }
             this.setValue(value.value);
         };


### PR DESCRIPTION
* Changed *phrase* param to *email* in UsersController.

Relates to https://github.com/siilats/traccarbolt/pull/11